### PR TITLE
offset: move offset clock into its own subpackage

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -11,6 +11,11 @@
 // until some number of other goroutines are sleeping.
 // See the documentation on the individual methods of fake.Clock for more
 // specific documentation.
+//
+// The offset subpackage contains an offset.Clock type which simply adds a
+// constant offset to any interactions with an absolute time. This type is most
+// useful for simulating clock-skew/unsynchronization in combination with the
+// fake-clock.
 package clocks
 
 import (

--- a/offset/offset_clock.go
+++ b/offset/offset_clock.go
@@ -1,47 +1,51 @@
-package clocks
+package offset
 
 import (
 	"context"
 	"time"
+
+	clocks "github.com/vimeo/go-clocks"
 )
 
-// OffsetClock wraps another clock, adjusting time intervals by a constant
+// Clock wraps another clock, adjusting time intervals by adding a constant
 // offset. (useful for simulating clock-skew)
-type OffsetClock struct {
-	inner  Clock
+// Note that relative durations are unaffected.
+type Clock struct {
+	inner  clocks.Clock
 	offset time.Duration
 }
 
 // Now implements Clock, returning the current time (according to the captive
 // clock adjusted by offset)
-func (o *OffsetClock) Now() time.Time {
+func (o *Clock) Now() time.Time {
 	return o.inner.Now().Add(o.offset)
 }
 
 // Until implements Clock, returning the difference between the current time
 // and its argument (according to the captive clock adjusted by offset)
-func (o *OffsetClock) Until(t time.Time) time.Duration {
+func (o *Clock) Until(t time.Time) time.Duration {
 	return o.inner.Until(t) + o.offset
 }
 
 // SleepUntil blocks until either ctx expires or until arrives.
 // Return value is false if context-cancellation/expiry prompted an
 // early return
-func (o *OffsetClock) SleepUntil(ctx context.Context, until time.Time) bool {
+func (o *Clock) SleepUntil(ctx context.Context, until time.Time) bool {
 	return o.inner.SleepUntil(ctx, until.Add(o.offset))
 }
 
-// SleepFor is the relative-time equivalent of SleepUntil. In the
-// default implementation, this is the lower-level method, but other
-// implementations may disagree.
-func (o *OffsetClock) SleepFor(ctx context.Context, dur time.Duration) bool {
+// SleepFor is the relative-time equivalent of SleepUntil.
+// Return value is false if context-cancellation/expiry prompted an
+// early return
+func (o *Clock) SleepFor(ctx context.Context, dur time.Duration) bool {
 	// SleepFor is relative, so it doesn't need any adjustment
 	return o.inner.SleepFor(ctx, dur)
 }
 
-// NewOffsetClock creates an OffsetClock and returns it
-func NewOffsetClock(inner Clock, offset time.Duration) *OffsetClock {
-	return &OffsetClock{
+// NewOffsetClock creates an OffsetClock.
+// offset is added to all absolute times
+func NewOffsetClock(inner clocks.Clock, offset time.Duration) *Clock {
+	return &Clock{
 		inner:  inner,
 		offset: offset,
 	}

--- a/offset/offset_clock_test.go
+++ b/offset/offset_clock_test.go
@@ -1,0 +1,82 @@
+package offset
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/vimeo/go-clocks/fake"
+)
+
+func TestOffsetClock(t *testing.T) {
+	base := time.Now()
+	inner := fake.NewClock(base)
+	const o = time.Minute + 3*time.Second
+	c := NewOffsetClock(inner, o)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if n := c.Now(); !base.Add(o).Equal(n) {
+		t.Errorf("unexpected time from Now(): %s; expected %s",
+			n, base.Add(o))
+	}
+
+	if d := c.Until(base.Add(time.Hour)); d != (time.Hour + o) {
+		t.Errorf("unexpected value for c.Until(%s); got %s; expected %s",
+			base.Add(time.Hour), d, (time.Hour + o))
+	}
+
+	{
+		expectedWakeInner := base.Add(time.Hour)
+		ch := make(chan bool)
+		go func() {
+			ch <- c.SleepFor(ctx, time.Hour)
+		}()
+		inner.AwaitSleepers(1)
+
+		if sl := inner.Sleepers(); len(sl) != 1 || !sl[0].Equal(expectedWakeInner) {
+			t.Errorf("unexpected sleepers: %v; expected 1 with %s", sl, expectedWakeInner)
+		}
+
+		select {
+		case v := <-ch:
+			t.Fatalf("SleepFor exited prematurely with value %t", v)
+		default:
+		}
+
+		if awoken := inner.Advance(time.Hour); awoken != 1 {
+			t.Errorf("unexpected number of awoken waiters: %d; expected 1", awoken)
+		}
+
+		if v := <-ch; !v {
+			t.Errorf("unexpected return value from SleepFor; %t; expected true", v)
+		}
+	}
+	{
+		expectedWakeInner := base.Add(2 * time.Hour)
+		ch := make(chan bool)
+		go func() {
+			ch <- c.SleepUntil(ctx, expectedWakeInner.Add(-o))
+		}()
+		inner.AwaitSleepers(1)
+
+		if sl := inner.Sleepers(); len(sl) != 1 || !sl[0].Equal(expectedWakeInner) {
+			t.Errorf("unexpected sleepers: %v; expected 1 with %s", sl, expectedWakeInner)
+		}
+
+		select {
+		case v := <-ch:
+			t.Fatalf("SleepFor exited prematurely with value %t", v)
+		default:
+		}
+
+		if awoken := inner.Advance(time.Hour); awoken != 1 {
+			t.Errorf("unexpected number of awoken waiters: %d; expected 1", awoken)
+		}
+
+		if v := <-ch; !v {
+			t.Errorf("unexpected return value from SleepUntil; %t; expected true", v)
+		}
+	}
+}


### PR DESCRIPTION
Also add tests covering all methods, taking significant advantage of the
fake clock.

Clean up the type-documentation a bit.