### PR TITLE
Add AfterFunc to Clock interface

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -50,6 +50,10 @@ func (c defaultClock) SleepFor(ctx context.Context, d time.Duration) bool {
 	return true
 }
 
+func (c defaultClock) AfterFunc(d time.Duration, f func()) StopTimer {
+	return time.AfterFunc(d, f)
+}
+
 // DefaultClock returns a clock that minimally wraps the `time` package
 func DefaultClock() Clock {
 	return defaultClock{}
@@ -70,4 +74,10 @@ type Clock interface {
 	// default implementation, this is the lower-level method, but other
 	// implementations may disagree.
 	SleepFor(ctx context.Context, dur time.Duration) bool
+
+	// AfterFunc is a time-relative primitive, equivalent to time.AfterFunc.
+	// (in the default clock, it *is* delegated directly to time.AfterFunc)
+	// The callback function f will be executed after the interval d has
+	// elapsed, unless the returned timer's Stop() method is called first.
+	AfterFunc(d time.Duration, f func()) StopTimer
 }

--- a/clock_test.go
+++ b/clock_test.go
@@ -42,4 +42,10 @@ func TestDefaultClock(t *testing.T) {
 	if v := <-ch; v {
 		t.Errorf("unexpected return value for SleepUntil (and by extension SleepFor): %t; expected false", v)
 	}
+
+	{
+		afCh := make(chan struct{})
+		c.AfterFunc(time.Millisecond, func() { close(afCh) })
+		<-afCh
+	}
 }

--- a/offset/offset_clock.go
+++ b/offset/offset_clock.go
@@ -42,6 +42,13 @@ func (o *Clock) SleepFor(ctx context.Context, dur time.Duration) bool {
 	return o.inner.SleepFor(ctx, dur)
 }
 
+// AfterFunc executes function f after duration d, (delegating to the wrapped
+// clock, as the time-argument is relative)
+func (o *Clock) AfterFunc(d time.Duration, f func()) clocks.StopTimer {
+	// relative time, so nothing to do here, just delegate on down.
+	return o.inner.AfterFunc(d, f)
+}
+
 // NewOffsetClock creates an OffsetClock.
 // offset is added to all absolute times
 func NewOffsetClock(inner clocks.Clock, offset time.Duration) *Clock {

--- a/timer.go
+++ b/timer.go
@@ -1,0 +1,10 @@
+package clocks
+
+// StopTimer exposes a `Stop()` method for an equivalent object to time.Timer
+// (in the defaultClock case, it may be an actual time.Timer)
+type StopTimer interface {
+	// Stop attempts to prevent a timer from firing, returning true if it
+	// succeeds in preventing the timer from firing, and false if it
+	// already fired.
+	Stop() bool
+}


### PR DESCRIPTION
Per request by @justinruggles 

This adds a `StopTimer` interface for the return value, as `AfterFunc`'s timer is only needed for its `Stop()` method.
Updates the `fake.Clock` to support the new `AfterFunc` and add appropriate introspection/waiting methods.

Note: all three packages still have 100% test coverage:
```
% go test -count 3 -cover  ./...
ok      github.com/vimeo/go-clocks      0.010s  coverage: 100.0% of statements
ok      github.com/vimeo/go-clocks/fake 0.002s  coverage: 100.0% of statements
ok      github.com/vimeo/go-clocks/offset       0.007s  coverage: 100.0% of statements
```