### PR TITLE
fake: track spawned goroutines

### DIFF
--- a/fake/fake_clock_test.go
+++ b/fake/fake_clock_test.go
@@ -432,6 +432,7 @@ func TestFakeClockAfterFuncTimeWake(t *testing.T) {
 	cbRun := make(chan struct{})
 	timerHandle := fc.AfterFunc(time.Hour, func() { close(cbRun) })
 
+	fc.WaitAfterFuncs()
 	<-aggCallbackWaitCh
 	<-regCallbackWaitCh
 
@@ -536,8 +537,10 @@ func TestFakeClockAfterFuncTimeAbort(t *testing.T) {
 	cbRun := make(chan struct{})
 	timerHandle := fc.AfterFunc(time.Hour, func() { close(cbRun) })
 
+	fc.WaitAfterFuncs()
 	<-aggCallbackWaitCh
 	<-regCallbackWaitCh
+	fc.WaitAfterFuncs()
 
 	if regCBs := fc.NumRegisteredCallbacks(); regCBs != 1 {
 		t.Errorf("unexpected registered callbacks: %d; expected 1", regCBs)
@@ -617,6 +620,7 @@ func TestFakeClockAfterFuncNegDur(t *testing.T) {
 
 	cbRun := make(chan struct{})
 	timerHandle := fc.AfterFunc(-time.Hour, func() { close(cbRun) })
+	fc.WaitAfterFuncs()
 	<-aggCallbackWaitCh
 	<-cbRun
 


### PR DESCRIPTION
Since AfterFunc configured callbacks are run in newly spawned
goroutines, it's useful to at least have the guarantee that they've
started when Advance and SetClock return. Also add a WaitGroup to track
when those goroutines complete.

cc: @justinruggles 