### PR TITLE
fake: fix loop variable capture in setClockLocked

### DIFF
--- a/fake/fake_clock.go
+++ b/fake/fake_clock.go
@@ -81,11 +81,11 @@ func (f *Clock) setClockLocked(t time.Time, cbRunningWG *sync.WaitGroup) int {
 		if target.Sub(t) <= 0 {
 			cbRunningWG.Add(1)
 			f.cbsWG.Add(1)
-			go func() {
+			go func(st *stopTimer) {
 				defer f.cbsWG.Done()
 				cbRunningWG.Done()
-				s.f()
-			}()
+				st.f()
+			}(s)
 			delete(f.cbs, s)
 			cbsRun++
 		}


### PR DESCRIPTION
Fix a bug that would cause, afterfuncs to run multiple times. Since the
loop variable was captured and not copied, if there were multiple
registered callbacks (they didn't have to be wakeable) they could be
executed prematurely or not at all depending on how the goroutine
executing for executing some other callback and the goroutine looping
over registered afterfuncs race.

This would cause the wrong callback to run, possibly multiple times.

The tests previously only registered one afterfunc at a time.