### PR TITLE
Build with Go 1.18 and 1.19

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,37 +7,29 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        goversion: [1.14, 1.15]
+        goversion: [1.18, 1.19]
     steps:
       - name: Set up Go ${{matrix.goversion}} on ${{matrix.os}}
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: ${{matrix.goversion}}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: gofmt
         run: |
           [[ -z  $(gofmt -l $(find . -name '*.go') ) ]]
 
       - name: Get dependencies
-        env:
-          GO111MODULE: on
         run: go mod download
 
       - name: Vet
-        env:
-          GO111MODULE: on
         run: go vet -mod=readonly ./...
 
       - name: Test
-        env:
-          GO111MODULE: on
         run: go test -mod=readonly -v -count 2 ./...
 
       - name: Race Test
-        env:
-          GO111MODULE: on
         run: go test -race -mod=readonly -v -count 2 ./...


### PR DESCRIPTION
- as of this writing they are the current and previous major versions of Go.
- remove unnecessary GO111MODULE declarations (it defaults to `on` as of Go 1.17)