### PR TITLE
timer: Add a NewTimer method to Clock

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -62,6 +62,11 @@ func (c defaultClock) ContextWithTimeout(ctx context.Context, d time.Duration) (
 	return context.WithTimeout(ctx, d)
 }
 
+func (c defaultClock) NewTimer(d time.Duration) Timer {
+	t := time.NewTimer(d)
+	return &defaultTimer{Timer: t}
+}
+
 // DefaultClock returns a clock that minimally wraps the `time` package
 func DefaultClock() Clock {
 	return defaultClock{}
@@ -103,4 +108,14 @@ type Clock interface {
 	// uses the clock to determine the when the timeout has elapsed. Cause is
 	// ignored in Go 1.20 and earlier.
 	ContextWithTimeoutCause(ctx context.Context, d time.Duration, cause error) (context.Context, context.CancelFunc)
+
+	// NewTimer returns a Timer implementation which will fire after at
+	// least the specified duration [d]. The Ch() method returns a channel,
+	// and should be called inline with the receive or select case.
+	//
+	// Timers are most useful in select/case blocks. For simple cases,
+	// SleepFor should be preferred.
+	//
+	// Stop() is inherently racy. Be wary of the return value.
+	NewTimer(d time.Duration) Timer
 }

--- a/fake/fake_timer.go
+++ b/fake/fake_timer.go
@@ -1,0 +1,181 @@
+package fake
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type timerTracker struct {
+	// backpointer to the parent clock
+	fc *Clock
+
+	timers map[*fakeTimer]time.Time
+
+	mu sync.Mutex
+}
+
+type wakeRes struct {
+	notified int
+	awoken   int
+}
+
+// Returns the number of timers that were notified, followed by how many were
+// actually awoken (or at least a best-guess).
+func (t *timerTracker) wakeup(now time.Time) wakeRes {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := wakeRes{}
+	for ft, ttim := range t.timers {
+		// use After to reflect <= rather than <.
+		if ttim.After(now) {
+			continue
+		}
+		wres := ft.wake(now)
+		if wres.wasStopped {
+			continue
+		}
+		if wres.signaled {
+			out.awoken++
+			out.notified++
+		}
+		delete(t.timers, ft)
+	}
+	return out
+}
+
+func (t *timerTracker) registerTimer(ft *fakeTimer, wakeTime time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.timers[ft] = wakeTime
+}
+
+// returns true if the timer was previously present
+func (t *timerTracker) remove(ft *fakeTimer) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	_, present := t.timers[ft]
+	delete(t.timers, ft)
+	return present
+}
+
+func (t *timerTracker) registeredTimers() []time.Time {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]time.Time, 0, len(t.timers))
+	for _, t := range t.timers {
+		out = append(out, t)
+	}
+	return out
+}
+
+type refCnt struct {
+	i atomic.Int32
+}
+
+func (r *refCnt) inc() {
+	r.i.Add(1)
+}
+
+func (r *refCnt) dec() {
+	if v := r.i.Add(-1); v < 0 {
+		panic("negative refcount")
+	}
+}
+
+func (r *refCnt) val() int32 {
+	return r.i.Load()
+}
+
+type fakeTimer struct {
+	// backreference to tracker
+	tracker *timerTracker
+
+	ch chan time.Time
+
+	fired   atomic.Bool
+	stopped atomic.Bool
+
+	ptrExtracted refCnt
+}
+
+type ftWakeState struct {
+	ptrWasExtracted bool
+	wasStopped      bool
+	signaled        bool
+}
+
+func (f *fakeTimer) wake(now time.Time) ftWakeState {
+	stopped := f.stopped.Load()
+	f.fired.Store(true)
+	if stopped {
+		return ftWakeState{
+			ptrWasExtracted: false,
+			wasStopped:      stopped,
+			signaled:        false,
+		}
+	}
+
+	select {
+	case f.ch <- now:
+		return ftWakeState{
+			ptrWasExtracted: f.ptrExtracted.val() > 0,
+			wasStopped:      false,
+			signaled:        true,
+		}
+	default:
+		return ftWakeState{
+			ptrWasExtracted: f.ptrExtracted.val() > 0,
+			wasStopped:      false,
+			signaled:        false,
+		}
+	}
+}
+
+// Stop attempts to prevent a timer from firing, returning true if it
+// succeeds in preventing the timer from firing, and false if it
+// already fired.
+func (f *fakeTimer) Stop() bool {
+	f.tracker.remove(f)
+	f.stopped.Store(true)
+	fired := f.fired.Load()
+
+	f.tracker.fc.mu.Lock()
+	defer f.tracker.fc.mu.Unlock()
+	f.tracker.fc.timerAborts++
+	f.tracker.fc.cond.Broadcast()
+	return !fired
+}
+
+// Ch returns a pointer to the channel for the timer
+func (f *fakeTimer) Ch() *<-chan time.Time {
+	f.ptrExtracted.inc()
+
+	// Define this callback before chWrapper so it doesn't hold a reference
+	// and prevent the finalizer from running
+	chFin := func(any) {
+		f.ptrExtracted.dec()
+		f.tracker.fc.mu.Lock()
+
+		defer f.tracker.fc.mu.Unlock()
+		f.tracker.fc.extractedChans--
+		f.tracker.fc.cond.Broadcast()
+	}
+
+	chWrapper := struct {
+		ch <-chan time.Time
+	}{
+		ch: f.ch,
+	}
+
+	runtime.SetFinalizer(&chWrapper, chFin)
+
+	f.tracker.fc.mu.Lock()
+	defer f.tracker.fc.mu.Unlock()
+	f.tracker.fc.extractedChans++
+	f.tracker.fc.extractedChansAggregate++
+
+	f.tracker.fc.cond.Broadcast()
+	return &chWrapper.ch
+}

--- a/offset/offset_clock.go
+++ b/offset/offset_clock.go
@@ -49,6 +49,12 @@ func (o *Clock) AfterFunc(d time.Duration, f func()) clocks.StopTimer {
 	return o.inner.AfterFunc(d, f)
 }
 
+// NewTimer returns a timer from the wrapped clock's [clocks.Clock.NewTimer].
+func (o *Clock) NewTimer(d time.Duration) clocks.Timer {
+	// relative time, so nothing to do here, just delegate on down.
+	return o.inner.NewTimer(d)
+}
+
 // ContextWithDeadline behaves like context.WithDeadline, but it uses the
 // clock to determine the when the deadline has expired.
 func (o *Clock) ContextWithDeadline(ctx context.Context, t time.Time) (context.Context, context.CancelFunc) {
@@ -69,3 +75,5 @@ func NewOffsetClock(inner clocks.Clock, offset time.Duration) *Clock {
 		offset: offset,
 	}
 }
+
+var _ clocks.Clock = (*Clock)(nil)

--- a/timer.go
+++ b/timer.go
@@ -1,5 +1,7 @@
 package clocks
 
+import "time"
+
 // StopTimer exposes a `Stop()` method for an equivalent object to time.Timer
 // (in the defaultClock case, it may be an actual time.Timer).
 type StopTimer interface {
@@ -7,4 +9,23 @@ type StopTimer interface {
 	// succeeds in preventing the timer from firing, and false if it
 	// already fired.
 	Stop() bool
+}
+
+// Timer exposes methods for an equivalent object to time.Timer
+// (in the defaultClock case, it may be an actual time.Timer)
+type Timer interface {
+	StopTimer
+	// Ch returns the channel for the timer
+	// For the fake clock's tracking to work, one must always dereference
+	// the channel returned by this method directly, as it relies on a
+	// finalizer to figure out when a listening goroutine woke up.
+	Ch() *<-chan time.Time
+}
+
+type defaultTimer struct {
+	*time.Timer
+}
+
+func (d *defaultTimer) Ch() *<-chan time.Time {
+	return &d.C
 }


### PR DESCRIPTION
The select statement/block is a major strength of Go, but it provides a few challenges for the fake clock. In particular, we need a way to know when the channel has been extracted, and ideally when it's in use.

To support tracking how many timers have their channels extracted, we return a pointer to a channel that lives on an anonymous struct and leverage runtime.SetFinalizer to decrement a reference-count when it would get GC'd (likely because the select block was exited).

However, finalizers may be run a bit earlier than one would otherwise expect (the documentation for [runtime.SetFinalizer] indicates instruction/statement-level granularity on usage -- hence the existence of [runtime.KeepAlive])

Due to the laxness of the guarantees from runtime.SetFinalizer in the absense of caller-help with runtime.KeepaAlive calls, we don't expose the finalizer-based accounting, and leave those unexported.

We can decide later whether to remove the finalizer-based accounting. I'd like to get some mileage with it before deciding whether it would even be useful.

On the bright side, the call to get the channel gives us a signal as to when we're in the select block, and facilitates the AwaitAggExtractedChans, and NumAggExtractedChans methods.

[runtime.SetFinalizer]: https://pkg.go.dev/runtime#SetFinalizer
[runtime.KeepAlive]: https://pkg.go.dev/runtime#KeepAlive